### PR TITLE
fix: send 1 mojo

### DIFF
--- a/examples/chia-piggybank/01-Piggybank-QuickStart.md
+++ b/examples/chia-piggybank/01-Piggybank-QuickStart.md
@@ -41,7 +41,7 @@ The Clovyr Code environment comes with the testnet10 blockchain database pre-dow
 This script compiles the piggybank.clsp file to clvm, gets its puzzle hash, and forms a coin with zero mojos and this puzzle hash. 
 
 - `python3 -i ./piggybank_drivers.py` - load the piggybank python driver in interactive mode
-- `piggybank = deploy_smart_coin("piggybank.clsp", 0)` - deploy the piggybank contract with initial balance of 0
+- `piggybank = deploy_smart_coin("piggybank.clsp", 1)` - deploy the piggybank contract with initial balance of 1
 
 - Note `your_puzzle_hash`
 


### PR DESCRIPTION
When starting with 0 mojo this error occured to me:
deploy piggybank.clsp with 0 mojos to dbccb7afc40b18c1752ea57f2c15ff7995956d11ec5a1ff21c9ed44358c15c12 in 67.37 seconds.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "./piggybank_drivers.py", line 111, in deploy_smart_coin
    print(f"coin_id: {coin.get_hash().hex()}")
AttributeError: 'NoneType' object has no attribute 'get_hash'