### PR TITLE
fix: remove params to show current wallet state

### DIFF
--- a/examples/chia-piggybank/01-Piggybank-QuickStart.md
+++ b/examples/chia-piggybank/01-Piggybank-QuickStart.md
@@ -54,4 +54,4 @@ We create a contribution coin, which spends funds from our wallet into a contrib
 
 ## Verify savings dump to new coin
  - `CTRL + D` to exit the python interpreter (will unset the values of `piggybank`, `contribution_100`, & `contribution_200`)
- - `cdv rpc coinrecords --by puzhash [your_puzzle_hash] -ou -s 570135 -nd`
+ - `cdv rpc coinrecords --by puzhash [your_puzzle_hash]`

--- a/examples/chia-piggybank/01-Piggybank-QuickStart.md
+++ b/examples/chia-piggybank/01-Piggybank-QuickStart.md
@@ -54,4 +54,4 @@ We create a contribution coin, which spends funds from our wallet into a contrib
 
 ## Verify savings dump to new coin
  - `CTRL + D` to exit the python interpreter (will unset the values of `piggybank`, `contribution_100`, & `contribution_200`)
- - `cdv rpc coinrecords --by puzhash [your_puzzle_hash]`
+ - `cdv rpc coinrecords --by puzhash [your_puzzle_hash] -ou -s 460000 -nd`


### PR DESCRIPTION
Had to remove those options to correctly show the state of the coins in the wallet
I believe the example is from a non test net block height